### PR TITLE
Fix post bootanim freeze

### DIFF
--- a/ui/sdl2-xbox.c
+++ b/ui/sdl2-xbox.c
@@ -125,7 +125,7 @@ static void sdl2_gl_render_surface(struct sdl2_console *scon)
         if (display_tex) {
 
             // Make sure to wait for rendering to finish
-            glWaitSync(fence, 0, GL_TIMEOUT_IGNORED);
+            //glWaitSync(fence, 0, GL_TIMEOUT_IGNORED);
 
             // Render the surface to this fbo
             glViewport(0, 0, ww, wh);


### PR DESCRIPTION
Some users (mainly with AMD cards it seems(?)) get stuck after the boot animation with just the X.
This change fixes it for me, hopefully it does for others too.